### PR TITLE
StdのIteratorの実装の変更に対応

### DIFF
--- a/lib/monad/writer.fix
+++ b/lib/monad/writer.fix
@@ -57,7 +57,7 @@ write = |e| writer_t $ pure $ (e, ());
 
 // Gets the envirionment from a generic writer monad.
 get_env_t: [m: Monad] WriterT e m a -> m e;
-get_env_t = |ma| ma.@data.bind(@0 >> pure);
+get_env_t = |ma| ma.@data.bind(Tuple2::@0 >> pure);
 
 // Gets the envirionment from a writer monad.
 get_env: Writer e a -> e;
@@ -65,7 +65,7 @@ get_env = |ma| ma.get_env_t.get;
 
 // Gets the value from a generic writer monad.
 get_value_t: [m: Monad] WriterT e m a -> m a;
-get_value_t = |ma| ma.@data.bind(@1 >> pure);
+get_value_t = |ma| ma.@data.bind(Tuple2::@1 >> pure);
 
 // Gets the value from a writer monad.
 get_value: Writer e a -> a;

--- a/lib/trait/monoid.fix
+++ b/lib/trait/monoid.fix
@@ -17,15 +17,15 @@ trait a: MEmpty {
 trait Monoid = Semigroup + MEmpty;
 
 // Concats an iterator of monoids to a monoid.
-mconcat: [a: Monoid] Iterator a -> a;
-mconcat = |iter| iter.fold(mempty, |a,b| a.sappend(b));
+mconcat: [a: Monoid] DynIterator a -> a;
+mconcat = |iter| iter.fold(mempty, |b,a| a.sappend(b));
 
 impl Array a: MEmpty {
     mempty = [];
 }
 
-impl Iterator a: MEmpty {
-    mempty = Iterator::empty;
+impl DynIterator a: MEmpty {
+    mempty = DynIterator::empty;
 }
 
 impl String: MEmpty {

--- a/lib/trait/semigroup.fix
+++ b/lib/trait/semigroup.fix
@@ -18,8 +18,8 @@ impl Array a: Semigroup {
 }
 
 // For iterators, `sappend` appends two iterators.
-impl Iterator a: Semigroup {
-    sappend = Iterator::append;
+impl DynIterator a: Semigroup {
+    sappend = |rhs, lhs| lhs.append(rhs).to_dyn;
 }
 
 // For strings, `sappend` concats two strings.

--- a/tests/monad/reader_test.fix
+++ b/tests/monad/reader_test.fix
@@ -18,7 +18,7 @@ test_reader_functor = (
     assert_equal("eq", "3", r.run_reader([2]))
 );
 
-type Config = Iterator (String, String);
+type Config = DynIterator (String, String);
 
 test_reader_monad: TestCase;
 test_reader_monad = (
@@ -32,11 +32,11 @@ test_reader_monad = (
         let value2 = *get_config_value("key2");
         pure $ "value1=" + value1 + " value2=" + value2
     };
-    let config = Iterator::empty.push_front(("key1", "a")).push_front(("key2", "b"));
+    let config = Iterator::empty.push_front(("key1", "a")).push_front(("key2", "b")).to_dyn;
     eval *assert_equal("case1", "value1=a value2=b", r.run_reader(config));
-    let rr = r.local(push_front(("key2", "bb")));
+    let rr = r.local(|config| config.push_front(("key2", "bb")).to_dyn);
     eval *assert_equal("case2", "value1=a value2=bb", rr.run_reader(config));
-    eval *assert_equal("case3", "value1= value2=bb", rr.run_reader(Iterator::empty));
+    eval *assert_equal("case3", "value1= value2=bb", rr.run_reader(DynIterator::empty));
     pure()
 );
 

--- a/tests/trait/monoid_test.fix
+++ b/tests/trait/monoid_test.fix
@@ -21,11 +21,11 @@ test_array = (
 test_iterator: TestCase;
 test_iterator = (
     make_test("test_iterator") $ |_|
-    let a: Iterator I64 = mempty;
+    let a: DynIterator I64 = mempty;
     let _ = *assert_equal("mempty", [], a.to_array);
-    let a = a.sappend([1].to_iter);
+    let a = a.sappend([1].to_iter.to_dyn);
     let _ = *assert_equal("sappend", [1], a.to_array);
-    let a = a.sappend([2,3].to_iter);
+    let a = a.sappend([2,3].to_iter.to_dyn);
     let _ = *assert_equal("sappend", [1,2,3], a.to_array);
     pure()
 );


### PR DESCRIPTION
StdのIteratorの実装の変更に対応しました。

get_env_tとget_value_tの「@0」と「@1」に名前空間を明示しないとコンパイルできないようでしたので、追記しました（最近のコンパイラの変更による影響なのか、現時点で不明です）。